### PR TITLE
Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,52 @@
+
+# Setting Up
+## Python Virtual Environment
+This project uses python [Virtual Environments](https://docs.python.org/3/tutorial/venv.html).
+
+Create the venv. Only needs to be done once.
+```
+python3 -m venv ./env
+```
+Activate the venv.
+```
+source ./env/bin/activate
+```
+Once the venv is activated, `python` refers to python3.
+Upgrade pip and install all python dependancies. 
+```
+python -m pip install -U pip
+python -m pip install -r requirements.txt
+```
+
+To deactivate venv.
+```
+deactivate
+```
+
+## Getting around sudo password
+To disable asking password for sudo commands (required by powermetrics).
+Run `sudo visudo` and add the last line to User specification (replacing `<user>`):
+```
+# root and users in group wheel can run anything on any machine as any user
+root ALL = (ALL) ALL
+%admin ALL = (ALL) ALL
+<user> ALL = (ALL) NOPASSWD:ALL
+```
+
 # How to use these scripts
-* ./benchmakrk.py --measure ./results
-* ./benchmakrk.py --profile ./profile
+```
+./benchmakrk.py --measure ./results
+./benchmakrk.py --profile ./profile
+```
 
 ## benchmark.py
 Use to execute different usage scenarios and measure their power use using powermetrics.
 
 ## powermetrics_compare.py
 Parses and aggregates powermetrics results generated from benchmark.py --measure, generating a csv for each benchmark, and one for a high level summary.
+```
+./powermetrics_compare.py ./results
+```
 
 ## pages/
 This directory contains special webpages that can be loaded from disk in a navigator to verify certain behaviors.
@@ -24,11 +64,3 @@ Runnning the Chrome vs Chrome benchmarks require the use of signed builds. To do
 2. Find your code signing identity using `security find-identity -v -p codesigning`
 3. Follow the chrome signing [instructions](https://source.chromium.org/chromium/chromium/src/+/master:chrome/installer/mac/signing/README.md)
 4. Now you have a signed build!
-
-# Getting around sudo password
-To disable asking password for sudo commands (powermetrics).
-Run `sudo visudo` and add the last line to User specification (replacing <user>):
-
-root            ALL = (ALL) ALL
-%admin          ALL = (ALL) ALL
-<user>        ALL = (ALL) NOPASSWD:ALL

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 
 # Setting Up
 ## Python Virtual Environment
@@ -32,6 +33,20 @@ root ALL = (ALL) ALL
 %admin ALL = (ALL) ALL
 <user> ALL = (ALL) NOPASSWD:ALL
 ```
+=======
+# Environment setup
+
+## sudo
+Running benchmark.py in either measure or profile mode requires the user to have sudoer access. Running the whole script as `sudo` works but should be done with care. The scripts work when ran as normal users and attempt to run only the necessary commands as sudo. If sudo access of the shell expires while the script is running correct behavior is not guaranteed.
+
+## dtrace
+Running benchmark.py in profile mode uses `dtrace` to analyse the chromium processes. By default `dtrace` does not work well with [SIP](https://support.apple.com/en-us/HT204899). Disabling SIP as a whole is not recommended and instead should be done only for dtrace using these steps:
+
+* Reboot in recovery mode
+* Start a shell
+* Execute `csrutil enable --without dtrace --without debug`
+* Reboot
+>>>>>>> Update README.md
 
 ## benchmark.py
 Use to execute different usage scenarios and measure their power use using powermetrics.
@@ -39,6 +54,11 @@ Use to execute different usage scenarios and measure their power use using power
 ./benchmakrk.py --measure ./results
 ./benchmark.py profile --profile_mode cpu_time --chromium_executable=./bin/Chromium.app
 ```
+
+Example commands:
+
+* ./benchmakrk.py --measure ./results
+* ./benchmark.py profile --profile_mode cpu_time --chromium_executable=./bin/Chromium.app
 
 ## powermetrics_compare.py
 Parses and aggregates powermetrics results generated from benchmark.py --measure, generating a csv for each benchmark, and one for a high level summary.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Running benchmark.py in profile mode uses `dtrace` to analyse the chromium proce
 ## benchmark.py
 Use to execute different usage scenarios and measure their power use using powermetrics.
 ```
-./benchmakrk.py --measure ./results
-./benchmark.py profile --profile_mode cpu_time --chromium_executable=./bin/Chromium.app
+./benchmark.py ./results --measure 
+./benchmark.py ./profile --profile_mode cpu_time --chromium_executable=./bin/Chromium.app
 ```
 
 ## powermetrics_compare.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # How to use these scripts
 * ./benchmakrk.py --measure ./results
 * ./benchmakrk.py --profile ./profile
+* ./benchmark.py profile --profile_mode cpu_time --chromium_executable=./bin/Chromium.app
 
 ## benchmark.py
 Use to execute different usage scenarios and measure their power use using powermetrics.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ Runnning the Chrome vs Chrome benchmarks require the use of signed builds. To do
 2. Find your code signing identity using `security find-identity -v -p codesigning`
 3. Follow the chrome signing [instructions](https://source.chromium.org/chromium/chromium/src/+/master:chrome/installer/mac/signing/README.md)
 4. Now you have a signed build!
+
+# Getting around sudo password
+To disable asking password for sudo commands (powermetrics).
+Run `sudo visudo` and add the last line to User specification (replacing <user>):
+
+root            ALL = (ALL) ALL
+%admin          ALL = (ALL) ALL
+<user>        ALL = (ALL) NOPASSWD:ALL

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
-# How to use these scripts
-* ./benchmakrk.py --measure ./results
-* ./benchmakrk.py --profile ./profile
-* ./benchmark.py profile --profile_mode cpu_time --chromium_executable=./bin/Chromium.app
+# Environment setup
+
+## sudo
+Running benchmark.py in either measure or profile mode requires the user to have sudoer access. Running the whole script as `sudo` works but should be done with care. The scripts work when ran as normal users and attempt to run only the necessary commands as sudo. If sudo access of the shell expires while the script is running correct behavior is not guaranteed.
+
+## dtrace
+Running benchmark.py in profile mode uses `dtrace` to analyse the chromium processes. By default `dtrace` does not work well with [SIP](https://support.apple.com/en-us/HT204899). Disabling SIP as a whole is not recommended and instead should be done only for dtrace using these steps:
+
+* Reboot in recovery mode
+* Start a shell
+* Execute `csrutil enable --without dtrace --without debug`
+* Reboot
 
 ## benchmark.py
 Use to execute different usage scenarios and measure their power use using powermetrics.
+
+Example commands:
+
+* ./benchmakrk.py --measure ./results
+* ./benchmark.py profile --profile_mode cpu_time --chromium_executable=./bin/Chromium.app
 
 ## powermetrics_compare.py
 Parses and aggregates powermetrics results generated from benchmark.py --measure, generating a csv for each benchmark, and one for a high level summary.

--- a/README.md
+++ b/README.md
@@ -33,14 +33,12 @@ root ALL = (ALL) ALL
 <user> ALL = (ALL) NOPASSWD:ALL
 ```
 
-# How to use these scripts
-```
-./benchmakrk.py --measure ./results
-./benchmakrk.py --profile ./profile
-```
-
 ## benchmark.py
 Use to execute different usage scenarios and measure their power use using powermetrics.
+```
+./benchmakrk.py --measure ./results
+./benchmark.py profile --profile_mode cpu_time --chromium_executable=./bin/Chromium.app
+```
 
 ## powermetrics_compare.py
 Parses and aggregates powermetrics results generated from benchmark.py --measure, generating a csv for each benchmark, and one for a high level summary.

--- a/benchmark.py
+++ b/benchmark.py
@@ -46,10 +46,11 @@ def RunScenario(scenario_config):
   process = subprocess.Popen(driver_script_args)
 
   # Wait for the browser to be started before continuing on.
-  browser_process_name = utils.browsers_definition[scenario_config.browser]['process_name']
-  while not FindBrowserProcess(browser_process_name):
-    time.sleep(0.100)
-    print(f"Waiting for {browser_process_name} to start")
+  if scenario_config.browser:
+    browser_process_name = utils.browsers_definition[scenario_config.browser]['process_name']
+    while not FindBrowserProcess(browser_process_name):
+      time.sleep(0.100)
+      print(f"Waiting for {browser_process_name} to start")
 
   return process
 
@@ -197,15 +198,15 @@ def main():
   KillPowermetrics()
   os.makedirs(f"{args.output_dir}", exist_ok=True)
 
-  # Verify that we run in an environment condusive to proper profiling or measurments.
-  try:
-    check_env = subprocess.run(['zsh', '-c', 'source ./check_env.sh && CheckEnv'], check=not args.no_checks, capture_output=True)
-    print("WARNING:", check_env.stdout.decode('ascii'))
-  except subprocess.CalledProcessError as e:
-    print("ERROR:", e.stdout.decode('ascii'))
-    return
-
   if args.run_measure:
+  # Verify that we run in an environment condusive to proper measurments.
+    try:
+      check_env = subprocess.run(['zsh', '-c', 'source ./check_env.sh && CheckEnv'], check=not args.no_checks, capture_output=True)
+      print("WARNING:", check_env.stdout.decode('ascii'))
+    except subprocess.CalledProcessError as e:
+      print("ERROR:", e.stdout.decode('ascii'))
+      return
+
     Record(ScenarioConfig("idle", "idle", None, None, None), args.output_dir)
     Record(ScenarioConfig("canary_idle_on_wiki_slack", "canary_idle_on_wiki", browser="Canary", extra_args=["--enable-features=LudicrousTimerSlack"], background_script=None), args.output_dir)
     Record(ScenarioConfig("canary_idle_on_wiki_slack_noslack", "canary_idle_on_wiki", browser="Canary", extra_args=["--disable-features=LudicrousTimerSlack"], background_script=None), args.output_dir)

--- a/benchmark.py
+++ b/benchmark.py
@@ -193,20 +193,20 @@ def main():
   if args.chromium_executable:
       utils.browsers_definition["Chromium"]["executable"] = args.chromium_executable
 
+  # Verify that we run in an environment condusive to proper measurments.
+  try:
+    check_env = subprocess.run(['zsh', '-c', 'source ./check_env.sh && CheckEnv'], check=not args.no_checks, capture_output=True)
+    print("WARNING:", check_env.stdout.decode('ascii'))
+  except subprocess.CalledProcessError as e:
+    print("ERROR:", e.stdout.decode('ascii'))
+    return
+
   # Start by making sure that no browsers are running which would affect the test.
   KillBrowsers(utils.browsers_definition.keys())
   KillPowermetrics()
   os.makedirs(f"{args.output_dir}", exist_ok=True)
 
   if args.run_measure:
-  # Verify that we run in an environment condusive to proper measurments.
-    try:
-      check_env = subprocess.run(['zsh', '-c', 'source ./check_env.sh && CheckEnv'], check=not args.no_checks, capture_output=True)
-      print("WARNING:", check_env.stdout.decode('ascii'))
-    except subprocess.CalledProcessError as e:
-      print("ERROR:", e.stdout.decode('ascii'))
-      return
-
     Record(ScenarioConfig("idle", "idle", None, None, None), args.output_dir)
     Record(ScenarioConfig("canary_idle_on_wiki_slack", "canary_idle_on_wiki", browser="Canary", extra_args=["--enable-features=LudicrousTimerSlack"], background_script=None), args.output_dir)
     Record(ScenarioConfig("canary_idle_on_wiki_slack_noslack", "canary_idle_on_wiki", browser="Canary", extra_args=["--disable-features=LudicrousTimerSlack"], background_script=None), args.output_dir)


### PR DESCRIPTION
- Child processes are now correctly followed
- Choose between wakeups and cpu_time profiling!
- Execution waits for dtrace to complete symbolizing after scenario has run.
- Add more instruction to README.md
- dtrace output is sent to a log file since most of the time it's of little interest.